### PR TITLE
Added support for `--not=<return_code>`

### DIFF
--- a/sample.t
+++ b/sample.t
@@ -1,3 +1,5 @@
 TEST hello
 TEST echo "Hello\nWorld" | grep "H"
 TEST ls /tmp/abcd
+TEST --ret 1 ls /tmp/abcd
+TEST --not 0 ls /tmp/abcd


### PR DESCRIPTION
If not sure about the return value of a command then
use `--not=<return_code>`.

For example,

```
TEST --not=0 ls /non/existing
```

Signed-off-by: Aravinda Vishwanathapura <aravinda@kadalu.io>