### PR TITLE
Added support for executing tests over SSH

### DIFF
--- a/binnacle/binnacle_utils.rc
+++ b/binnacle/binnacle_utils.rc
@@ -1,14 +1,15 @@
 NODE=local
+PORT=22
 
 function TEST()
 {
-    NODE=$NODE python3 -m binnacle.tester TEST "$@"
+    PORT=$PORT NODE=$NODE python3 -m binnacle.tester TEST "$@"
 }
 
 
 function EXPECT()
 {
-    NODE=$NODE python3 -m binnacle.tester EXPECT "$@"
+    PORT=$PORT NODE=$NODE python3 -m binnacle.tester EXPECT "$@"
 }
 
 function testplan()

--- a/binnacle/main.py
+++ b/binnacle/main.py
@@ -25,23 +25,27 @@ def get_args():
 
 
 def main():
-    args = get_args()
-    testsdir = os.path.dirname(args.testfile)
     try:
-        os.makedirs(os.path.join(testsdir, ".run"))
-    except FileExistsError:
-        pass
+        args = get_args()
+        testsdir = os.path.dirname(args.testfile)
+        try:
+            os.makedirs(os.path.join(testsdir, ".run"))
+        except FileExistsError:
+            pass
 
-    newpath = os.path.join(testsdir, ".run", os.path.basename(args.testfile))
-    testparser.parse_write(
-        args.testfile,
-        newpath
-    )
-    cmd = [args.prove_command]
-    if args.verbose:
-        cmd.append("-v")
-    cmd.append(newpath)
-    os.system(" ".join(cmd))
+        newpath = os.path.join(testsdir, ".run", os.path.basename(
+            args.testfile))
+        testparser.parse_write(
+            args.testfile,
+            newpath
+        )
+        cmd = [args.prove_command]
+        if args.verbose:
+            cmd.append("-v")
+        cmd.append(newpath)
+        os.system(" ".join(cmd))
+    except KeyboardInterrupt:
+        sys.exit(1)
 
 
 if __name__ == "__main__":

--- a/binnacle/tester.py
+++ b/binnacle/tester.py
@@ -5,14 +5,17 @@ from binnacle import testutils
 
 
 def main():
-    node = os.environ.get("NODE", None)
-    subcmd = sys.argv[1]
-    func = getattr(testutils, "handle_%s" % subcmd, None)
-    if func is None:
-        print("Invalid subcommand", file=sys.stderr)
-        sys.exit(1)
+    try:
+        node = os.environ.get("NODE", None)
+        subcmd = sys.argv[1]
+        func = getattr(testutils, "handle_%s" % subcmd, None)
+        if func is None:
+            print("Invalid subcommand", file=sys.stderr)
+            sys.exit(1)
 
-    func(node, sys.argv[2:])
+        func(node, sys.argv[2:])
+    except KeyboardInterrupt:
+        sys.exit(1)
 
 
 if __name__ == "__main__":

--- a/sample_ssh.t
+++ b/sample_ssh.t
@@ -1,0 +1,9 @@
+NODE=mynode
+PORT=2233
+
+TEST hello
+TEST echo "Hello\nWorld" | grep "H"
+TEST ls /tmp/abcd
+TEST --ret 2 ls /tmp/abcd
+TEST --not 0 ls /tmp/abcd
+EXPECT -v "Hello World" echo "Hello World"


### PR DESCRIPTION
Example:

```
NODE=mynode
PORT=2233

TEST echo "Hello\nWorld" | grep "H"
TEST ls /tmp/abcd
TEST --ret 2 ls /tmp/abcd
TEST --not 0 ls /tmp/abcd
EXPECT -v "Hello World" echo "Hello World"
```

Signed-off-by: Aravinda Vishwanathapura <aravinda@kadalu.io>