### PR TITLE
Fixes and new Test command

### DIFF
--- a/docs/installation.adoc
+++ b/docs/installation.adoc
@@ -4,7 +4,7 @@ Download and install using the following commands. Ruby should be installed on t
 
 [source,console]
 ----
-$ curl -L https://github.com/kadalu/binnacle/releases/download/0.3.0/binnacle -o binnacle
+$ curl -L https://github.com/kadalu/binnacle/releases/latest/download/binnacle -o binnacle
 ----
 
 Make the binnacle file executable.

--- a/docs/introduction.adoc
+++ b/docs/introduction.adoc
@@ -15,9 +15,14 @@ and run the test using,
 [source,console]
 ----
 $ binnacle test_ssh_key_initialized.t
-TOTAL: 1  PASSED: 1  FAILED: 0  SKIPPED: 0  TODOs: 0
-Result: PASS
-DURATION: 0.118192311 seconds
+ok       1 - node=local cmd="TEST stat ~/.ssh/id_rsa.pub"
+
+
+STATUS  TESTS  PASSED  FAILED  DUR(SEC)  SPEED(TPM)  INDEX DUR(SEC)  FILE
+=========================================================================
+OK          1       1      0          0           0               0
+
+Result: Pass
 ----
 
 Use `-v` for verbose output. Verbose output is compatible with TAP.
@@ -25,11 +30,21 @@ Use `-v` for verbose output. Verbose output is compatible with TAP.
 [source,console]
 ----
 $ binnacle test_ssh_key_initialized.t -v
-1..1
-ok       1 - node=local cmd="stat ~/.ssh/id_rsa.pub"
-TOTAL: 1  PASSED: 1  FAILED: 0  SKIPPED: 0  TODOs: 0
-Result: PASS
-DURATION: 0.115948522 seconds
+Indexing test files... done.  tests=1  test_files=1  duration_seconds=0
+
+
+------- STARTED(tests=1, file="test_ssh_key_initialized.t")
+ok       1 - node=local cmd="TEST stat ~/.ssh/id_rsa.pub"
+------- COMPLETED(OK, tests=1, passed=1, failed=0)
+
+
+STATUS  TESTS  PASSED  FAILED  DUR(SEC)  SPEED(TPM)  INDEX DUR(SEC)  FILE
+=========================================================================
+OK          1       1      0          0           0               0  test_ssh_key_initialized.t
+-------------------------------------------------------------------------
+OK          1       1      0          0           0               0
+
+Result: Pass
 ----
 
 Similar to `TEST` keyword, Binnacle supports many keywords. Read more about supported keywords link:keywords.adoc[here].

--- a/docs/keywords.adoc
+++ b/docs/keywords.adoc
@@ -17,6 +17,17 @@ Or validate for a specific exit code
 TEST 1, "ls /non/existing/dir"
 ----
 
+== RUN
+
+This is very similar to `TEST` but ignores if any error. This will be useful when some cleanup command to be run but that may fail.
+
+For example,
+
+[source,ruby]
+----
+RUN losetup -d /dev/non_existing_dev
+----
+
 == EXPECT
 
 Runs the given command and validates the output only if exit code of the command is zero.

--- a/docs/quick-start.adoc
+++ b/docs/quick-start.adoc
@@ -6,7 +6,7 @@ Download and install using the following commands. Ruby should be installed on t
 
 [source,console]
 ----
-$ curl -L https://github.com/kadalu/binnacle/releases/download/0.3.0/binnacle -o binnacle
+$ curl -L https://github.com/kadalu/binnacle/releases/latest/download/binnacle -o binnacle
 ----
 
 Make the binnacle file executable.
@@ -43,11 +43,22 @@ Now run this test file by running,
 [source,console]
 ----
 $ binnacle hello.t -v
-1..1
-# stat: /var/www/html/index.html: stat: No such file or directory
+Indexing test files... done.  tests=1  test_files=1  duration_seconds=0
+
+
+------- STARTED(tests=1, file="/hello.t")
 not ok   1 - node=local cmd="TEST stat /var/www/html/index.html"
-TOTAL: 1  PASSED: 0  FAILED: 1  SKIPPED: 0  TODOs: 0
-Result: FAIL
+# stat: cannot stat '/var/www/html/index.html': No such file or directory
+------- COMPLETED(NOT OK, tests=1, passed=0, failed=1)
+
+
+STATUS  TESTS  PASSED  FAILED  DUR(SEC)  SPEED(TPM)  INDEX DUR(SEC)  FILE
+=========================================================================
+NOT OK      1       0      1          0           0               0  /hello.t
+-------------------------------------------------------------------------
+NOT OK      1       0      1          0           0               0
+
+Result: Fail
 ----
 
 If that file exists then it will print the output as below
@@ -55,8 +66,19 @@ If that file exists then it will print the output as below
 [source,console]
 ----
 $ binnacle hello.t -v
-1..1
+Indexing test files... done.  tests=1  test_files=1  duration_seconds=0
+
+
+------- STARTED(tests=1, file="/hello.t")
 ok       1 - node=local cmd="TEST stat /var/www/html/index.html"
-TOTAL: 1  PASSED: 1  FAILED: 0  SKIPPED: 0  TODOs: 0
-Result: PASS
+------- COMPLETED(OK, tests=1, passed=1, failed=0)
+
+
+STATUS  TESTS  PASSED  FAILED  DUR(SEC)  SPEED(TPM)  INDEX DUR(SEC)  FILE
+=========================================================================
+OK          1       1      0          0           0               0  /hello.t
+-------------------------------------------------------------------------
+OK          1       1      0          0           0               0
+
+Result: Pass
 ----

--- a/src/binnacle.rb
+++ b/src/binnacle.rb
@@ -101,6 +101,11 @@ module Binnacle
           else
             puts line
           end
+        else
+          # Only print the Test case Summary line
+          if line.start_with?("ok") || line.start_with?("not ok")
+            puts line
+          end
         end
         outlines << line
       end

--- a/src/plugins.rb
+++ b/src/plugins.rb
@@ -172,4 +172,24 @@ module BinnacleTestPlugins
       BinnacleTestsRunner.NOT_OK(title, fail_message)
     end
   end
+
+  # Run any command and ignore if any Error
+  #
+  # ```
+  # RUN "rm -rf testdir"
+  # RUN "ls /non/existing"
+  # ```
+  def RUN(cmd)
+    return "" if BinnacleTestsRunner.dry_run?
+
+    ret, out, err = BinnacleTestsRunner.execute(cmd)
+    puts "# node=#{BinnacleTestsRunner.node} cmd=\"RUN #{cmd}\""
+
+    if ret != 0
+      puts "# #{err.split("\n").join("\n# ")}"
+    end
+
+    out
+  end
+
 end

--- a/src/runner.rb
+++ b/src/runner.rb
@@ -42,6 +42,10 @@ module BinnacleTestsRunner
     @@tests_count
   end
 
+  def self.escaped_cmd(cmd)
+    cmd.gsub("'", %Q['"'"'])
+  end
+
   # If node is not local then add respective prefix
   # to ssh or docker exec
   # TODO: support more options for ssh, like port and key
@@ -49,9 +53,9 @@ module BinnacleTestsRunner
     return cmd if @@node == "local"
 
     if @@remote_plugin == "ssh"
-      "ssh #{@@node} /bin/bash -c '#{cmd}'"
+      "ssh #{@@node} /bin/bash -c '#{escaped_cmd(cmd)}'"
     elsif @@remote_plugin == "docker"
-      "docker exec -i #{@@node} /bin/bash -c '#{cmd}'"
+      "docker exec -i #{@@node} /bin/bash -c '#{escaped_cmd(cmd)}'"
     else
       cmd
     end


### PR DESCRIPTION
1)
Fixed handling single quote while executing the bash command.
For example, below test will pass now.

```ruby
USE_REMOTE_PLUGIN "docker"
USE_NODE "server1"

TEST "awk 'BEGIN {FS = \":\"} /Snapshot Count:/ {print $2}' /root/volinfo.dat"
```

Above test will be expanded as

Before:

```
docker exec -i server1 /bin/bash -c 'awk 'BEGIN {FS = ":"} /Snapshot Count:/ {print $2}' /root/volinfo.dat'
```

After:

```
docker exec -i server1 /bin/bash -c 'awk '"'"'BEGIN {FS = ":"} /Snapshot Count:/ {print $2}'"'"' /root/volinfo.dat'
```

2)
New Command `RUN` is introduced. This is similar to `TEST` but
ignores if any errors.

```ruby
RUN losetup -d /dev/vhd1
```

3)
Print individual test summary in non-verbose mode. Without this there is
no way to know that which test is failed without using `-v`.

Signed-off-by: Aravinda Vishwanathapura <aravinda@kadalu.io>