### PR TITLE
New command: EXIT_ON_NOT_OK

### DIFF
--- a/docs/keywords.adoc
+++ b/docs/keywords.adoc
@@ -126,3 +126,22 @@ end
 # Continue with default plugin
 TEST "command 3"
 ----
+
+== EXIT_ON_NOT_OK
+
+By default, on error of a test case Test file execution is not terminated. Use this option to Halt the execution on error when required.
+
+[source,ruby]
+----
+TEST "command 1"
+
+# On setting this all future tests will use this setting
+EXIT_ON_NOT_OK true
+TEST "command 2"
+
+# Only use this setting for some commands
+EXIT_ON_NOT_OK true do
+    TEST "command 3"
+    TEST "command 4"
+end
+----

--- a/src/metrics.rb
+++ b/src/metrics.rb
@@ -1,13 +1,15 @@
 require "json"
 
 class Metrics
-  attr_reader :total, :passed, :duration_seconds,
+  attr_reader :total, :passed, :failed, :skipped, :duration_seconds,
               :total_files, :passed_files,
               :index_duration_seconds, :files, :ignored_files
 
   def initialize
     @total = 0
     @passed = 0
+    @failed = 0
+    @skipped = 0
     @duration_seconds = 0
     @speed_tpm = 0
     @total_files = 0
@@ -33,6 +35,7 @@ class Metrics
       :total => count,
       :passed => 0,
       :failed => 0,
+      :skipped => 0,
       :ok => false,
       :duration_seconds => 0,
       :speed_tpm => 0,
@@ -58,25 +61,24 @@ class Metrics
     @total == @passed
   end
 
-  def failed
-    @total - @passed
-  end
-
   def failed_files
     @total_files - @passed_files
   end
 
-  def file_completed(test_file, passed, duration_seconds)
+  def file_completed(test_file, passed, failed, skipped, duration_seconds)
     idx = @files_index[test_file]
     @files[idx][:passed] = passed
     @files[idx][:duration_seconds] = duration_seconds
     if duration_seconds > 0
       @files[idx][:speed_tpm] = (@files[idx][:total] * 60 / duration_seconds.to_f).round
     end
-    @files[idx][:failed] = @files[idx][:total] - passed
+    @files[idx][:failed] = failed
+    @files[idx][:skipped] = skipped
     @files[idx][:ok] = @files[idx][:total] == passed
 
     @passed += passed
+    @failed += failed
+    @skipped += skipped
     @passed_files += 1 if @files[idx][:ok]
     @duration_seconds += duration_seconds
 

--- a/src/plugins.rb
+++ b/src/plugins.rb
@@ -55,6 +55,34 @@ module BinnacleTestPlugins
     BinnacleTestsRunner.remote_plugin = prev if !prev.nil?
   end
 
+  # Two ways to set the remote plugin
+  # Using as Block
+  #
+  # ```
+  # EXIT_ON_NOT_OK true do
+  #   TEST "stat /var/www/html/index.html"
+  # end
+  # ```
+  #
+  # or without block
+  #
+  # ```
+  # EXIT_ON_NOT_OK true
+  # TEST "stat /var/www/html/index.html"
+  # ```
+  def EXIT_ON_NOT_OK(flag)
+    if !block_given?
+      BinnacleTestsRunner.exit_on_not_ok = flag
+      return
+    end
+
+    prev = BinnacleTestsRunner.exit_on_not_ok?
+    BinnacleTestsRunner.exit_on_not_ok = flag
+    yield
+  ensure
+    BinnacleTestsRunner.exit_on_not_ok = prev if !prev.nil?
+  end
+
   # Test any command for its return code
   #
   # ```
@@ -81,6 +109,8 @@ module BinnacleTestPlugins
     ret, out, err = BinnacleTestsRunner.execute(cmd)
     BinnacleTestsRunner.CMD_OK_NOT_OK(cmd, ret, out, err, expect_ret)
 
+    exit if (BinnacleTestsRunner.exit_on_not_ok? && ret != 0)
+
     out
   end
 
@@ -98,6 +128,7 @@ module BinnacleTestPlugins
 
     if ret != 0
       BinnacleTestsRunner.CMD_OK_NOT_OK(cmd, ret, out, err, 0)
+      exit if BinnacleTestsRunner.exit_on_not_ok?
     else
       if "#{expect_value}" == out.strip
         BinnacleTestsRunner.OK(cmd)
@@ -106,6 +137,7 @@ module BinnacleTestPlugins
           cmd,
           "\"#{expect_value}\"(Expected) != \"#{out.strip}\"(Actual)"
         )
+        exit if BinnacleTestsRunner.exit_on_not_ok?
       end
     end
   end
@@ -146,6 +178,7 @@ module BinnacleTestPlugins
       BinnacleTestsRunner.OK(title)
     else
       BinnacleTestsRunner.NOT_OK(title, fail_message)
+      exit if BinnacleTestsRunner.exit_on_not_ok?
     end
   end
 
@@ -170,6 +203,7 @@ module BinnacleTestPlugins
       BinnacleTestsRunner.OK(title)
     else
       BinnacleTestsRunner.NOT_OK(title, fail_message)
+      exit if BinnacleTestsRunner.exit_on_not_ok?
     end
   end
 

--- a/src/runner.rb
+++ b/src/runner.rb
@@ -5,6 +5,7 @@ module BinnacleTestsRunner
   @@tests_count = 0
   @@node = "local"
   @@remote_plugin = "ssh"
+  @@exit_on_not_ok = false
 
   # Only for getting the number of tests
   def self.dry_run?
@@ -32,6 +33,14 @@ module BinnacleTestsRunner
 
   def self.remote_plugin
     @@remote_plugin
+  end
+
+  def self.exit_on_not_ok=(flag)
+    @@exit_on_not_ok = flag
+  end
+
+  def self.exit_on_not_ok?
+    @@exit_on_not_ok
   end
 
   def self.inc_counter


### PR DESCRIPTION
Use this command when early exit is required or when no meaning to run
tests on a critical Test failure. For example, if setup is failed then
running all tests is meaningless.

Only exits on failure of command 2 and 3

```ruby
TEST "command 1"
EXIT_ON_NOT_OK true
TEST "command 2"
TEST "command 3"
EXIT_ON_NOT_OK false
TEST "command 4"
```

Alternate way

```ruby
TEST "command 1"
EXIT_ON_NOT_OK true do
    TEST "command 2"
    TEST "command 3"
end
TEST "command 4"
```

Signed-off-by: Aravinda Vishwanathapura <aravinda@kadalu.io>