### PR TITLE
Use `.chomp` to remove only last newline from stdout lines.

### DIFF
--- a/src/plugins.rb
+++ b/src/plugins.rb
@@ -221,7 +221,7 @@ module BinnacleTestPlugins
     out = []
     BinnacleTestsRunner.execute(cmd) do |stdout_line, stderr_line, ret|
       unless stdout_line.nil?
-        out << stdout_line.rstrip
+        out << stdout_line
         puts "# #{stdout_line}" if BinnacleTestsRunner.emit_stdout?
       end
       STDERR.puts "# #{stderr_line}" unless stderr_line.nil?
@@ -247,7 +247,7 @@ module BinnacleTestPlugins
 
     BinnacleTestsRunner.execute(cmd) do |stdout_line, stderr_line, ret|
       unless stdout_line.nil?
-        out << stdout_line.rstrip
+        out << stdout_line
         puts "# #{stdout_line}" if BinnacleTestsRunner.emit_stdout?
       end
       STDERR.puts "# #{stderr_line}" unless stderr_line.nil?
@@ -346,7 +346,7 @@ module BinnacleTestPlugins
     out = []
     BinnacleTestsRunner.execute(cmd) do |stdout_line, stderr_line, ret|
       unless stdout_line.nil?
-        out << stdout_line.rstrip
+        out << stdout_line
         puts "# #{stdout_line}" if BinnacleTestsRunner.emit_stdout?
       end
       STDERR.puts "# #{stderr_line}" unless stderr_line.nil?

--- a/src/runner.rb
+++ b/src/runner.rb
@@ -136,9 +136,9 @@ module BinnacleTestsRunner
         Thread.new do
           until (line = stream.gets).nil? do
             if key == :out
-              yield line, nil, nil
+              yield line.chomp, nil, nil
             else
-              yield nil, line, nil
+              yield nil, line.chomp, nil
             end
           end
         end


### PR DESCRIPTION
Signed-off-by: Aravinda Vishwanathapura <aravinda@kadalu.tech>