### PR TITLE
Make base URL optional for ReST API plugin

### DIFF
--- a/lib/kadalu/binnacle/plugins/commands.rb
+++ b/lib/kadalu/binnacle/plugins/commands.rb
@@ -3,48 +3,48 @@
 # rubocop:disable Metrics/ModuleLength
 module Kadalu
   module Binnacle
-    # Two ways to set the remote plugin
+    # Two ways to set the command_mode
     # Using as Block
     #
     # ```
-    # use_remote_plugin "docker" do
-    #   test "stat /var/www/html/index.html"
+    # command_mode "docker" do
+    #   command_test "stat /var/www/html/index.html"
     # end
     # ```
     #
     # or without block
     #
     # ```
-    # use_remote_plugin "docker"
-    # test "stat /var/www/html/index.html"
+    # command_mode "docker"
+    # command_test "stat /var/www/html/index.html"
     # ```
-    register_plugin 'use_remote_plugin' do |plugin, &block|
-      Store.set(:remote_plugin, plugin, &block)
+    register_plugin 'command_mode' do |plugin, &block|
+      Store.set(:command_mode, plugin, &block)
     end
 
     # For backward compatibility
     register_plugin 'USE_REMOTE_PLUGIN' do |plugin, &block|
-      Store.set(:remote_plugin, plugin, &block)
+      Store.set(:command_mode, plugin, &block)
     end
 
-    default_config(:remote_plugin, 'ssh')
+    default_config(:command_mode, 'local')
 
     # Two ways to set the node
     # Using as Block
     #
     # ```
-    # use_node "node1.example.com" do
-    #   test "stat /var/www/html/index.html"
+    # command_node "node1.example.com" do
+    #   command_test "stat /var/www/html/index.html"
     # end
     # ```
     #
     # or without block
     #
     # ```
-    # use_node "node1.example.com"
-    # test "stat /var/www/html/index.html"
+    # command_node "node1.example.com"
+    # command_test "stat /var/www/html/index.html"
     # ```
-    register_plugin 'use_node' do |value, &block|
+    register_plugin 'command_node' do |value, &block|
       Store.set(:node_name, value, &block)
     end
 
@@ -53,7 +53,7 @@ module Kadalu
       Store.set(:node_name, value, &block)
     end
 
-    register_plugin 'use_container' do |value, &block|
+    register_plugin 'command_container' do |value, &block|
       Store.set(:node_name, value, &block)
     end
 
@@ -79,7 +79,7 @@ module Kadalu
 
     default_config(:exit_on_not_ok, false)
 
-    register_plugin 'use_sudo' do |value: true, &block|
+    register_plugin 'command_sudo' do |value: true, &block|
       Store.set(:sudo, value, &block)
     end
 
@@ -90,7 +90,7 @@ module Kadalu
       Store.set(:sudo, value, &block)
     end
 
-    register_plugin 'use_ssh_user' do |value, &block|
+    register_plugin 'command_ssh_user' do |value, &block|
       Store.set(:ssh_user, value, &block)
     end
 
@@ -101,7 +101,7 @@ module Kadalu
       Store.set(:ssh_user, value, &block)
     end
 
-    register_plugin 'use_ssh_pem_file' do |value, &block|
+    register_plugin 'command_ssh_pem_file' do |value, &block|
       Store.set(:ssh_pem_file, value, &block)
     end
 
@@ -112,7 +112,7 @@ module Kadalu
 
     default_config(:ssh_pem_file, '~/.ssh/id_rsa')
 
-    register_plugin 'use_ssh_port' do |value, &block|
+    register_plugin 'command_ssh_port' do |value, &block|
       Store.set(:ssh_port, value, &block)
     end
 
@@ -126,21 +126,21 @@ module Kadalu
     # Test any command for its return code
     #
     # ```
-    # run "ls /etc/hosts"
+    # command_run "ls /etc/hosts"
     # ```
     #
     # or for any specific return code
     #
     # ```
-    # run 1, "ls /non/existing"
+    # command_run 1, "ls /non/existing"
     # ```
     #
     # To ignore errors, use `nil` return code
     #
     # ```
-    # run nil, "ls /non/existing"
+    # command_run nil, "ls /non/existing"
     # ```
-    register_plugin 'run' do |*args, **_kwargs|
+    register_plugin 'command_run' do |*args, **_kwargs|
       expect_ret = 0
       cmd = args[0]
       if args.size > 1
@@ -175,7 +175,7 @@ module Kadalu
     register_plugin 'RUN' do |cmd|
       data = {}
       Store.set(:response, 'return') do
-        data = Plugins.run(nil, cmd)
+        data = Plugins.command_run(nil, cmd)
       end
 
       data
@@ -184,24 +184,24 @@ module Kadalu
     # Test any command for its return code
     #
     # ```
-    # test "ls /etc/hosts"
+    # command_test "ls /etc/hosts"
     # ```
     #
     # or for any specific return code
     #
     # ```
-    # test 1, "ls /non/existing"
+    # command_test 1, "ls /non/existing"
     # ```
     #
     # To ignore errors, use `nil` return code
     #
     # ```
-    # test nil, "ls /non/existing"
+    # command_test nil, "ls /non/existing"
     # ```
-    register_plugin 'test' do |*args, **_kwargs|
+    register_plugin 'command_test' do |*args, **_kwargs|
       data = {}
       Store.set(:response, 'return') do
-        data = Plugins.run(*args)
+        data = Plugins.command_run(*args)
       end
 
       data
@@ -210,17 +210,17 @@ module Kadalu
     register_plugin 'TEST' do |*args, **_kwargs|
       data = {}
       Store.set(:response, 'return') do
-        data = Plugins.run(*args)
+        data = Plugins.command_run(*args)
       end
 
       data
     end
 
-    register_plugin 'expect' do |expect_value, cmd|
+    register_plugin 'command_expect' do |expect_value, cmd|
       data = {}
       Store.set(:response, 'return') do
         # TODO: If expect_value is multiline or a variable is given
-        data = Plugins.run(0, cmd)
+        data = Plugins.command_run(0, cmd)
       end
 
       if data[:ok] && data[:output] != expect_value.to_s
@@ -243,7 +243,7 @@ module Kadalu
     register_plugin 'EXPECT' do |expect_value, cmd|
       data = {}
       Store.set(:response, 'return') do
-        data = Plugins.expect(expect_value, cmd)
+        data = Plugins.command_expect(expect_value, cmd)
       end
 
       data

--- a/lib/kadalu/binnacle/plugins/compare.rb
+++ b/lib/kadalu/binnacle/plugins/compare.rb
@@ -5,13 +5,13 @@ module Kadalu
     # Validate if the given two values are equal
     #
     # ```
-    # is_equal 10, 10, "Test Title"
+    # compare_equal? 10, 10, "Test Title"
     # ```
     #
     # ```
-    # is_equal var1, 100, "Value is 100"
+    # compare_equal? var1, 100, "Value is 100"
     # ```
-    register_plugin 'is_equal' do |value1, value2, title = ''|
+    register_plugin 'compare_equal?' do |value1, value2, title = ''|
       ok = value1 == value2
       unless ok
         puts <<-MSG
@@ -39,7 +39,7 @@ module Kadalu
     register_plugin 'EQUAL' do |value1, value2, title = ''|
       data = {}
       Store.set(:response, 'return') do
-        data = Plugins.is_equal(value1, value2, title)
+        data = Plugins.compare_equal?(value1, value2, title)
       end
 
       data
@@ -48,13 +48,13 @@ module Kadalu
     # Validate if the given two values are equal
     #
     # ```
-    # is_not_equal 11, 10, "Test Title"
+    # compare_not_equal? 11, 10, "Test Title"
     # ```
     #
     # ```
-    # is_not_equal var1, 100, "Value is 100"
+    # compare_not_equal? var1, 100, "Value is 100"
     # ```
-    register_plugin 'is_not_equal' do |value1, value2, title = ''|
+    register_plugin 'compare_not_equal?' do |value1, value2, title = ''|
       ok = value1 != value2
       unless ok
         puts <<-MSG
@@ -77,7 +77,7 @@ module Kadalu
     register_plugin 'NOT_EQUAL' do |value1, value2, title = ''|
       data = {}
       Store.set(:response, 'return') do
-        data = Plugins.is_not_equal(value1, value2, title)
+        data = Plugins.compare_not_equal?(value1, value2, title)
       end
 
       data
@@ -86,9 +86,9 @@ module Kadalu
     # Validate if the given statement is true
     #
     # ```
-    # is_true var1 == 10, "Test Title"
+    # compare_true? var1 == 10, "Test Title"
     # ```
-    register_plugin 'is_true' do |expr, title = ''|
+    register_plugin 'compare_true?' do |expr, title = ''|
       {
         ok: expr == true,
         title: title
@@ -99,7 +99,7 @@ module Kadalu
     register_plugin 'TRUE' do |expr, title = ''|
       data = {}
       Store.set(:response, 'return') do
-        data = Plugins.is_true(expr, title)
+        data = Plugins.compare_true?(expr, title)
       end
 
       data
@@ -108,9 +108,9 @@ module Kadalu
     # Validate if the given statement is false
     #
     # ```
-    # is_false var1 == 10, "Test Title"
+    # compare_false? var1 == 10, "Test Title"
     # ```
-    register_plugin 'is_false' do |expr, title = ''|
+    register_plugin 'compare_false?' do |expr, title = ''|
       {
         ok: expr == false,
         title: title
@@ -121,7 +121,7 @@ module Kadalu
     register_plugin 'FALSE' do |expr, title = ''|
       data = {}
       Store.set(:response, 'return') do
-        data = Plugins.is_false(expr, title)
+        data = Plugins.compare_false?(expr, title)
       end
 
       data

--- a/lib/kadalu/binnacle/plugins/http.rb
+++ b/lib/kadalu/binnacle/plugins/http.rb
@@ -26,6 +26,8 @@ module Kadalu
       Store.set(:base_url, URI.parse(value), &block)
     end
 
+    default_config(:base_url, URI.parse(""))
+
     # Two ways to set the Basic auth
     # Using as Block
     #
@@ -102,7 +104,9 @@ module Kadalu
 
     def self.get_http_from_url(url, kwargs)
       uri = Store.get(:base_url)
-      uri = URI.join(uri.to_s, url)
+
+      # If full URL is given in sub commands then use the same instead of using Base URL
+      uri = url.start_with?("http") ? URI.parse(url) : URI.join(uri.to_s, url)
 
       query = kwargs.fetch(:query, nil)
 
@@ -175,6 +179,8 @@ module Kadalu
 
     def self.set_headers(request)
       headers = Store.get(:request_headers)
+      return if headers.nil?
+
       headers.each do |key, value|
         request[key] = value.to_s
       end

--- a/lib/kadalu/binnacle/utils.rb
+++ b/lib/kadalu/binnacle/utils.rb
@@ -17,9 +17,9 @@ module Kadalu
       @files = {}
 
       def node_or_container_label(data)
-        if Store.get(:use_remote_plugin) == 'ssh'
+        if Store.get(:command_mode) == 'ssh'
           data[:node] = Store.get(:node_name)
-        elsif Store.get(:use_remote_plugin) == 'docker'
+        elsif Store.get(:command_mode) == 'docker'
           data[:container] = Store.get(:node_name)
         end
       end
@@ -90,13 +90,13 @@ module Kadalu
       # If node is not local then add respective prefix
       # to ssh or docker exec
       def full_cmd(cmd)
-        return cmd if Store.get(:node_name) == 'local'
+        return cmd if Store.get(:command_mode) == 'local'
 
-        if Store.get(:remote_plugin) == 'ssh'
+        if Store.get(:command_mode) == 'ssh'
           "ssh #{Store.get(:ssh_user)}@#{Store.get(:node_name)} " \
           "-i #{Store.get(:ssh_pem_file)} -p #{Store.get(:ssh_port)} " \
           "'#{escaped_ssh_cmd(cmd)}'"
-        elsif Store.get(:remote_plugin) == 'docker'
+        elsif Store.get(:command_mode) == 'docker'
           "docker exec -i #{Store.get(:node_name)} /bin/bash -c '#{escaped_cmd(cmd)}'"
         else
           cmd


### PR DESCRIPTION
- Each sub commands `http_get/http_post/http_put/http_delete` accepts full URLs
- Renamed commands and added plugin prefix to many commands
- Updated the docs